### PR TITLE
Improve energy efficiency by applying Reduce Size Energy Pattern

### DIFF
--- a/app/src/main/java/com/mkulesh/onpc/iscp/messages/JacketArtMsg.java
+++ b/app/src/main/java/com/mkulesh/onpc/iscp/messages/JacketArtMsg.java
@@ -165,7 +165,7 @@ public class JacketArtMsg extends ISCPMessage
 
             URLConnection urlConnection = url.openConnection();
             urlConnection.setRequestProperty("Accept-Encoding", "gzip");
-            InputStream inputStream = null;
+            InputStream inputStream;
             if ("gzip".equals(urlConnection.getContentEncoding())) {
                 inputStream = new GZIPInputStream(urlConnection.getInputStream());
             } else {

--- a/app/src/main/java/com/mkulesh/onpc/iscp/messages/JacketArtMsg.java
+++ b/app/src/main/java/com/mkulesh/onpc/iscp/messages/JacketArtMsg.java
@@ -22,7 +22,10 @@ import com.mkulesh.onpc.utils.Logging;
 import com.mkulesh.onpc.utils.Utils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
+import java.util.zip.GZIPInputStream;
 
 import androidx.annotation.NonNull;
 
@@ -160,7 +163,15 @@ public class JacketArtMsg extends ISCPMessage
         {
             Logging.info(this, "loading image from URL: " + url.toString());
 
-            byte[] bytes = Utils.streamToByteArray(url.openConnection().getInputStream());
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setRequestProperty("Accept-Encoding", "gzip");
+            InputStream inputStream = null;
+            if ("gzip".equals(urlConnection.getContentEncoding())) {
+                inputStream = new GZIPInputStream(urlConnection.getInputStream());
+            } else {
+                inputStream = urlConnection.getInputStream();
+            }
+            byte[] bytes = Utils.streamToByteArray(inputStream);
             final int offset = getUrlHeaderLength(bytes);
             final int length = bytes.length - offset;
             if (length > 0)


### PR DESCRIPTION
This improves the energy efficiency of onpc by applying the Reduce Size Energy Pattern for mobile applications.
The energy pattern was applied in JacketArtMsg.java. The general idea is when receiving data from an URLConnection or subclasses, if possible, receive the data compressed by GZIP scheme. In this specific case, when receiving data from the urlConnection variable, request for the data to be compressed. 